### PR TITLE
[14.0][IMP] partner_security_manager: added auth_signup send email exception fields

### DIFF
--- a/partner_security_manager/__manifest__.py
+++ b/partner_security_manager/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "category": "Extra Tools",
     "website": "https://github.com/solvosci/slv-partner",
     "depends": ["base"],

--- a/partner_security_manager/models/res_partner.py
+++ b/partner_security_manager/models/res_partner.py
@@ -50,4 +50,6 @@ class ResPartner(models.Model):
             # added by "purchase", when creating RFQ
             "reminder_date_before_receipt",
             "receipt_reminder_email",
+            # added by "auth_signup", when e.g. sending an invoice
+            "signup_token", "signup_type", "signup_expiration",
         ]


### PR DESCRIPTION
When sending a PO, SO or INV new exception fields are required for non-administrator users

cc @ChristianSantamaria 